### PR TITLE
Move the database out of the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE $PORT
 
 COPY ./ /minitwit
 WORKDIR /minitwit
-RUN cp /minitwit/minitwit.db /tmp/minitwit.db
+
 
 RUN go mod tidy
 RUN go mod download

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,11 @@ services:
   minitwit-go:
     container_name: minitwit-go
     image: minitwit-go:latest
+    build: .
     environment:
       - SERVER_HOST=localhost
       - DB_CONNECTION_STRING=/tmp/minitwit.db
     ports:
       - 8080:8080
+    volumes:
+      - ../data/:/tmp/


### PR DESCRIPTION
To make sure that we wont loose the database again like we did in #83 Then we have moved the database outside the application. 

This revision is the service that is currently running on the server. along with: