### PR TITLE
MiniTwit-#47: Added foreign keys and unique constraints to follower

### DIFF
--- a/database/followerRepository.go
+++ b/database/followerRepository.go
@@ -23,6 +23,7 @@ func FollowUser(userId uint, UserIdToFollow uint) error {
 	}
 
 	if functions.ContainsUint(followerids, followed.UserId) {
+		log.Logger.Error().Err(err).Str("userId", fmt.Sprint(follower.UserId)).Msg("user already follows given user")
 		return errors.New("user already follows given user")
 	}
 
@@ -51,7 +52,10 @@ func UnFollowUser(userId uint, UserIdToUnFollow uint) error {
 		Delete(&Follower{}, obj)
 
 	if result.RowsAffected != 1 {
-		return errors.New("Could not remove the follower")
+		err := errors.New("Could not remove the follower, user is not following the given user")
+		log.Logger.Error().Err(err).Str("userId", fmt.Sprint(userId)).Msg(
+			fmt.Sprintf("Could not remove follower as user is not following the given user in id: %d", UserIdToUnFollow))
+		return err
 	}
 	return nil
 }

--- a/database/gorm.go
+++ b/database/gorm.go
@@ -26,8 +26,10 @@ func (User) TableName() string {
 // Maybe add a post migration script that adds it or live with it?.
 
 type Follower struct {
-	WhoId  uint `gorm:"column:who_id"`
-	WhomId uint `gorm:"column:whom_id"`
+	WhoId    uint `gorm:"uniqueIndex:compositeindex;column:who_id"`
+	WhoUser  User `gorm:"foreignKey:WhoId"`
+	WhomId   uint `gorm:"uniqueIndex:compositeindex;column:whom_id"`
+	WhomUser User `gorm:"foreignKey:WhomId"`
 }
 
 func (Follower) TableName() string {

--- a/logic/user.go
+++ b/logic/user.go
@@ -148,9 +148,8 @@ func UnFollowUser(userId uint, usernameToUnFollow string) error {
 		log.Logger.Error().Err(err).Caller().Str("username", usernameToUnFollow).Msg("Could not get user")
 		return err
 	}
-	// TODO: check if already following before trying this
-	err = database.UnFollowUser(userId, userToUnFollow.UserId)
 
+	err = database.UnFollowUser(userId, userToUnFollow.UserId)
 	if err != nil {
 		log.Logger.Error().Err(err).Caller().Str("follower", fmt.Sprint(userId)).Str("followed", usernameToUnFollow).Msg("Could not unfollow user")
 	}


### PR DESCRIPTION
- Foreign keys to reinforce integrity in DB
- Multi-column unique constraint to ensure no duplicates are present when a client might send faulty requests


I was not able to discern how we handle updating the DB in prod - there doesn't seem to be any migration-script, so maybe some further work might be required.