### PR TITLE
hack fix for unfollow

### DIFF
--- a/logic/user.go
+++ b/logic/user.go
@@ -134,8 +134,9 @@ func UnFollowUserFromUsername(followerUsername string, unfollowUsername string) 
 	err = database.UnFollowUser(follower.UserId, userToUnFollow.UserId)
 
 	if err != nil {
-		log.Logger.Error().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
-		return err
+		log.Logger.Warn().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
+		database.FollowUser(follower.UserId, userToUnFollow.UserId)
+		metrics.HackCreateFollowOnUnfollow.Inc()
 	}
 
 	return nil

--- a/logic/user.go
+++ b/logic/user.go
@@ -115,6 +115,8 @@ func UnFollowUserFromUsername(followerUsername string, unfollowUsername string) 
 			Password2: "123",
 		})
 		metrics.HackCreateUserOnFollow.Inc()
+		metrics.HackCreateFollowOnUnfollow.Inc()
+		return nil
 	}
 
 	userToUnFollow, err := database.GetUserFromDb(unfollowUsername)
@@ -128,6 +130,8 @@ func UnFollowUserFromUsername(followerUsername string, unfollowUsername string) 
 			Password2: "123",
 		})
 		metrics.HackCreateUserOnFollow.Inc()
+		metrics.HackCreateFollowOnUnfollow.Inc()
+		return nil
 	}
 
 	//TODO: Check that the user is not already following the user Issue #47
@@ -135,8 +139,6 @@ func UnFollowUserFromUsername(followerUsername string, unfollowUsername string) 
 
 	if err != nil {
 		log.Logger.Warn().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
-		metrics.HackCreateFollowOnUnfollow.Inc()
-		}
 	}
 
 	return nil

--- a/logic/user.go
+++ b/logic/user.go
@@ -135,14 +135,7 @@ func UnFollowUserFromUsername(followerUsername string, unfollowUsername string) 
 
 	if err != nil {
 		log.Logger.Warn().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
-		database.FollowUser(follower.UserId, userToUnFollow.UserId)
 		metrics.HackCreateFollowOnUnfollow.Inc()
-
-		// retry unfollow
-		err = database.UnFollowUser(follower.UserId, userToUnFollow.UserId)
-		if err != nil { // should succeed 100% of the time, but just in case
-			log.Logger.Error().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
-			return err
 		}
 	}
 

--- a/logic/user.go
+++ b/logic/user.go
@@ -137,6 +137,13 @@ func UnFollowUserFromUsername(followerUsername string, unfollowUsername string) 
 		log.Logger.Warn().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
 		database.FollowUser(follower.UserId, userToUnFollow.UserId)
 		metrics.HackCreateFollowOnUnfollow.Inc()
+
+		// retry unfollow
+		err = database.UnFollowUser(follower.UserId, userToUnFollow.UserId)
+		if err != nil { // should succeed 100% of the time, but just in case
+			log.Logger.Error().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
+			return err
+		}
 	}
 
 	return nil

--- a/metrics/hack.go
+++ b/metrics/hack.go
@@ -8,3 +8,10 @@ var HackCreateUserOnFollow = prometheus.NewCounter(
 		Help: "total number of times that a user have been created on follow",
 	},
 )
+
+var HackCreateFollowOnUnfollow = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "minitwit_total_hack_create_follow_on_unfollow",
+		Help: "total number of times that a follow entry has been created on unfollow",
+	},
+)

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -11,4 +11,5 @@ func init() {
 	prometheus.MustRegister(EndpointResponseTime)
 	prometheus.MustRegister(EndpointResponseTimeHistogram)
 	prometheus.MustRegister(HackCreateUserOnFollow)
+	prometheus.MustRegister(HackCreateFollowOnUnfollow)
 }


### PR DESCRIPTION
# For reviewer - please read this
Alternative to the current solution (create follow entry and remove again), don't create the follow entry, but just ignore and increment 1 for the hack.
What do you think?

The code would change from
```
if err != nil {
		log.Logger.Warn().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
		database.FollowUser(follower.UserId, userToUnFollow.UserId)
		metrics.HackCreateFollowOnUnfollow.Inc()
		// retry unfollow
		err = database.UnFollowUser(follower.UserId, userToUnFollow.UserId)
		if err != nil { // should succeed 100% of the time, but just in case
			log.Logger.Error().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
			return err
		}
	}
```
to just (and there would be no database calls)
```
if err != nil {
		log.Logger.Warn().Err(err).Caller().Str("follower", followerUsername).Str("followed", unfollowUsername).Msg("Could not unfollow user")
		metrics.HackCreateFollowOnUnfollow.Inc()
		}
	}
```